### PR TITLE
Fix Interfacer force close and denials

### DIFF
--- a/installd.te
+++ b/installd.te
@@ -126,3 +126,7 @@ allow installd devpts:chr_file rw_file_perms;
 
 # execute toybox for app relocation
 allow installd toolbox_exec:file rx_file_perms;
+
+# allow /data/data/ theme attributes for theme_data explicitly without macros
+allow installd theme_data_file:dir { add_name getattr read relabelto remove_name setattr write open search };
+allow installd theme_data_file:lnk_file { create getattr unlink };

--- a/interfacer.te
+++ b/interfacer.te
@@ -57,6 +57,7 @@ allow interfacer media_rw_data_file:file rw_file_perms;
 # Services
 allow interfacer activity_service:service_manager find;
 allow interfacer connectivity_service:service_manager find;
+allow interfacer content_service:service_manager find;
 allow interfacer display_service:service_manager find;
 allow interfacer mount_service:service_manager find;
 allow interfacer network_management_service:service_manager find;


### PR DESCRIPTION
07-29 20:34:00.755 E/SELinux (474): avc:  denied  { find } for service=content pid=14066 uid=1000 scontext=u:r:interfacer:s0 tcontext=u:object_r:content_service:s0 tclass=service_manager permissive=0